### PR TITLE
feat: implement web support with window.location.reload()

### DIFF
--- a/src/NativeRestart.web.ts
+++ b/src/NativeRestart.web.ts
@@ -1,1 +1,5 @@
-export default { restart: () => console.log("Restart not supported on web.") };
+export default {
+  restart: () => {
+    window.location.reload();
+  },
+};


### PR DESCRIPTION
## Summary

The current web stub in `NativeRestart.web.ts` only logs a message to the console, making the library non-functional on web platforms.

This PR replaces the no-op `console.log` with `window.location.reload()`, providing actual restart functionality for web.

### Before
```ts
export default { restart: () => console.log("Restart not supported on web.") };
```

### After
```ts
export default {
  restart: () => {
    window.location.reload();
  },
};
```

## Motivation

When using this library in a React Native app that also targets web (e.g., via Expo), calling `RNRestart.restart()` should actually reload the page rather than silently logging a message. `window.location.reload()` is the standard and expected behavior for restarting a web application.

## Test plan

- [x] Verified `window.location.reload()` works correctly in a React Native web app (Expo SDK 54)
- [x] No impact on iOS/Android — the `.web.ts` file is only resolved for web builds